### PR TITLE
Fix Build Error with Publish v0.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 
 /**
 *  SVGPlugin plugin for Publish
@@ -10,6 +10,7 @@ import PackageDescription
 
 let package = Package(
     name: "SVGPublishPlugin",
+    platforms: [.macOS(.v12)],
     products: [
         .library(
             name: "SVGPublishPlugin",

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
 		.package(name: "Publish", url: "https://github.com/johnsundell/publish.git", from: "0.8.0"),
-		.package(url: "https://github.com/c0dedbear/StrongTypedCSSPublishPlugin", from: "0.1.0")
+		.package(url: "https://github.com/c0dedbear/StrongTypedCSSPublishPlugin", from: "0.1.1")
     ],
     targets: [
 		.target(


### PR DESCRIPTION
Bumps `swift-tools-version` to `5.5` and require macOS 12.0.

Publish [0.9.0](https://github.com/JohnSundell/Publish/releases/tag/0.9.0) requires Swift 5.5 and macOS 12.0 Monterey. Attempting to build a package using the latest version of Publish and this plugin fails with the following error:

```
The package product 'Publish' requires minimum platform version 12.0 for the macOS platform, but this target supports 10.13
```

This change fixes that.

**NOTE:** this requires that the [PR](https://github.com/c0dedbear/StrongTypedCSSPublishPlugin/pull/1) for a similar change to StrongTypedCSSPublishPlugin be accepted first and should probably bump the required version of the StrongTypedCSSPublishPlugin dependency.